### PR TITLE
Bump to Tor 0.4.4.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ configure_flags="$*"
 # version number changes.  Tor uses it to make sure that it
 # only shuts down for missing "required protocols" when those protocols
 # are listed as required by a consensus after this date.
-AC_DEFINE(APPROX_RELEASE_DATE, ["2020-06-09"], # for 0.4.5.0-alpha-dev
+AC_DEFINE(APPROX_RELEASE_DATE, ["2020-11-12"], # for 0.4.4.6
           [Approximate date when this software was released. (Updated when the version changes.)])
 
 # "foreign" means we don't follow GNU package layout standards

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl Copyright (c) 2007-2019, The Tor Project, Inc.
 dnl See LICENSE for licensing information
 
 AC_PREREQ([2.63])
-AC_INIT([tor],[0.4.5.0-alpha-dev])
+AC_INIT([tor],[0.4.4.6])
 AC_CONFIG_SRCDIR([src/app/main/tor_main.c])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/contrib/win32build/tor-mingw.nsi.in
+++ b/contrib/win32build/tor-mingw.nsi.in
@@ -8,13 +8,13 @@
 !include "LogicLib.nsh"
 !include "FileFunc.nsh"
 !insertmacro GetParameters
-!define VERSION "0.4.5.0-alpha-dev"
+!define VERSION "0.4.4.6"
 !define INSTALLER "tor-${VERSION}-win32.exe"
 !define WEBSITE "https://www.torproject.org/"
 !define LICENSE "LICENSE"
 !define BIN "..\bin" ;BIN is where it expects to find tor.exe, tor-resolve.exe
-  
- 
+
+
 SetCompressor /SOLID LZMA ;Tighter compression
 RequestExecutionLevel user ;Updated for Vista compatibility
 OutFile ${INSTALLER}
@@ -29,7 +29,7 @@ VIProductVersion "${VERSION}"
 VIAddVersionKey "ProductName" "The Onion Router: Tor"
 VIAddVersionKey "Comments" "${WEBSITE}"
 VIAddVersionKey "LegalTrademarks" "Three line BSD"
-VIAddVersionKey "LegalCopyright" "©2004-2008, Roger Dingledine, Nick Mathewson. ©2009 The Tor Project, Inc. "
+VIAddVersionKey "LegalCopyright" "ï¿½2004-2008, Roger Dingledine, Nick Mathewson. ï¿½2009 The Tor Project, Inc. "
 VIAddVersionKey "FileDescription" "Tor is an implementation of Onion Routing. You can read more at ${WEBSITE}"
 VIAddVersionKey "FileVersion" "${VERSION}"
 
@@ -121,7 +121,7 @@ SectionEnd
 
 Section "Desktop" Desktop
    SetOutPath $INSTDIR
-   CreateShortCut "$DESKTOP\Tor.lnk" "$INSTDIR\tor.exe" "" "$INSTDIR\tor.ico" 
+   CreateShortCut "$DESKTOP\Tor.lnk" "$INSTDIR\tor.exe" "" "$INSTDIR\tor.ico"
 SectionEnd
 
 Section /o "Run at startup" Startup
@@ -271,4 +271,3 @@ Function ParseCmdLine
 		Quit
 	${EndIf}
 FunctionEnd
-

--- a/src/win32/orconfig.h
+++ b/src/win32/orconfig.h
@@ -217,7 +217,7 @@
 #define USING_TWOS_COMPLEMENT
 
 /* Version number of package */
-#define VERSION "0.4.5.0-alpha-dev"
+#define VERSION "0.4.4.6"
 
 #define HAVE_STRUCT_SOCKADDR_IN6
 #define HAVE_STRUCT_IN6_ADDR


### PR DESCRIPTION
Currently when using [https://github.com/BlockchainCommons/iOS-TorFramework](https://github.com/BlockchainCommons/iOS-TorFramework) you get an outdated Tor. These changes aim to bring the Tor submodule for `iOS-TorFramework` up to date to incorporate bug fixes and security improvements. I have not tested as updating the submodules fails for my own fork as it looks for a commit which does not exist.